### PR TITLE
Reflect that kind import fix merged into master for prelude

### DIFF
--- a/src/groups/purescript.dhall
+++ b/src/groups/purescript.dhall
@@ -376,7 +376,7 @@
 , prelude =
     { dependencies = [] : List Text
     , repo = "https://github.com/purescript/purescript-prelude.git"
-    , version = "ps-0.14"
+    , version = "master"
     }
 , profunctor =
     { dependencies =


### PR DESCRIPTION
This change allowed me to build one of my active PureScript projects with v0.14.0-rc2 this morning (it was erroring because `ps-0.14` branch no longer existed on the `purescript-prelude` repository). I wasn't sure how long-lived this temporary branch would be and how many others would stumble into the problem so I thought I would PR. Feel free to close if this branch is going away very soon.

Thanks for all the hard work for the release updates!